### PR TITLE
Fix typo in clearing _paranoid_destroy_args

### DIFF
--- a/lib/sequel/plugins/paranoid.rb
+++ b/lib/sequel/plugins/paranoid.rb
@@ -51,7 +51,7 @@ module Sequel::Plugins
         define_method("_destroy_delete") do
           # _destroy_delete does not take arguments.
           destroy_options = Thread.current[:_paranoid_destroy_args].first
-          Thread.current[:_paranoid_destory_args] = nil
+          Thread.current[:_paranoid_destroy_args] = nil
 
           # set the deletion time
           self.send("#{options[:deleted_at_field_name]}=", Time.now)


### PR DESCRIPTION
This hash key was misspelled, so it is never cleared, only overwritten.
This can result in unexpected behavior in rare cases.
