### PR TITLE
Namespace _paranoid_destroy_args to instances

### DIFF
--- a/lib/sequel/plugins/paranoid.rb
+++ b/lib/sequel/plugins/paranoid.rb
@@ -44,15 +44,15 @@ module Sequel::Plugins
         define_method("destroy") do |*args|
           # Save the variables threadsafe (because the locks have not been
           # initialized by sequel yet).
-          Thread.current[:_paranoid_destroy_args] = args
+          Thread.current["_paranoid_destroy_args_#{self.object_id}"] = args
 
           super(*args)
         end
 
         define_method("_destroy_delete") do
           # _destroy_delete does not take arguments.
-          destroy_options = Thread.current[:_paranoid_destroy_args].first
-          Thread.current[:_paranoid_destroy_args] = nil
+          destroy_options = Thread.current["_paranoid_destroy_args_#{self.object_id}"].first
+          Thread.current["_paranoid_destroy_args_#{self.object_id}"] = nil
 
           # set the deletion time
           self.send("#{options[:deleted_at_field_name]}=", Time.now)

--- a/spec/sequel/plugins/paranoid_spec.rb
+++ b/spec/sequel/plugins/paranoid_spec.rb
@@ -93,6 +93,22 @@ describe Sequel::Plugins::Paranoid do
     end
   end
 
+  describe "cascade delete" do
+    before do
+      @cascading_parent = SpecModelWithCascadeDelete.create :name => 'baz'
+      @cascading_child = SpecFragment.create :name => 'baz-child'
+
+      @cascading_child.spec_model = @cascading_parent
+      @cascading_child.save
+    end
+
+    it "successfully cascade deletes" do
+      @cascading_parent.destroy
+      expect(@cascading_parent.before_destroy_value).to be_true
+      expect(SpecFragment.present.all).to have(0).items
+    end
+  end
+
   describe :recover do
     before do
       @instance1.destroy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,3 +60,14 @@ end
 class SpecModelWithDeletedBy < Sequel::Model
   plugin :paranoid, :enable_deleted_by => true
 end
+
+class SpecModelWithCascadeDelete < SpecModel
+  plugin :paranoid
+  one_to_many :spec_fragment
+
+  def before_destroy
+    spec_fragments.each { |m| m.destroy }
+
+    super
+  end
+end


### PR DESCRIPTION
When cascade delete is used, `:_paranoid_destroy_args` isn't a good
enough key for use in `Thread.current`, because multiple `destroy`
methods get called, resulting in a NoMethodError. This change adds each
instance's `object_id` to the key, which means each instance can read
its own destroy args.

Before:
```
Parent.destroy -> :_paranoid_destroy_args set
---- cascade ----
      Child.destroy -> :_paranoid_destroy_args set
           ._destroy_delete -> _paranoid_destroy_args read
           ._destroy_delete -> _paranoid_destroy_args cleared
---- end cascade ----
      ._destroy_delete -> _paranoid_destroy_args read # ERROR!
      ._destroy_delete -> _paranoid_destroy_args cleared
```

After:
```
Parent.destroy -> :_paranoid_destroy_args_1 set
---- cascade ----
      Child.destroy -> :_paranoid_destroy_args_2 set
           ._destroy_delete -> _paranoid_destroy_args_2 read
           ._destroy_delete -> _paranoid_destroy_args_2 cleared
---- end cascade ----
      ._destroy_delete -> _paranoid_destroy_args_1 read # no error!
      ._destroy_delete -> _paranoid_destroy_args_1 cleared
```

@sdepold an alternative to this approach would be to somehow
store the destroy args in the instance itself, but that seemed like
it would be polluting for no reason. I'm definitely open to changes,
but would like to resolve this issue (which actually only has
become apparent since b03497 typo fix!)