### PR TITLE
Sequel oath to remove deleted default scope when updating an instance

### DIFF
--- a/lib/sequel/plugins/paranoid.rb
+++ b/lib/sequel/plugins/paranoid.rb
@@ -66,6 +66,23 @@ module Sequel::Plugins
         end
 
         #
+        # Sequel patch to allow updates to deleted instances
+        # when default scope is enabled
+        #
+
+        define_method("_update_without_checking") do |columns|
+          # figure out correct pk conditions (see base#this)
+          conditions = this.send(:joined_dataset?) ? qualified_pk_hash : pk_hash
+
+          # turn off with deleted, added the pk conditions back in
+          update_with_deleted_dataset = this.with_deleted.where(conditions)
+
+          # run the original update on the with_deleted dataset
+          update_with_deleted_dataset.update(columns)
+
+        end if(options[:enable_default_scope])
+
+        #
         # Method for undeleting an instance.
         #
 

--- a/spec/sequel/plugins/paranoid_spec.rb
+++ b/spec/sequel/plugins/paranoid_spec.rb
@@ -168,7 +168,7 @@ describe Sequel::Plugins::Paranoid do
 
   describe :default_scope do
     before do
-      SpecModelWithDefaultScope.dataset.delete
+      SpecModelWithDefaultScope.with_deleted.delete
 
       @instance1 = SpecModelWithDefaultScope.create(:name => 'foo')
       @instance2 = SpecModelWithDefaultScope.create(:name => 'bar')
@@ -177,6 +177,28 @@ describe Sequel::Plugins::Paranoid do
     it "does not return the deleted instances" do
       @instance1.destroy
       expect(SpecModelWithDefaultScope.all).to have(1).item
+    end
+
+    it "can still undelete an instance" do
+      @instance1.destroy
+      expect(SpecModelWithDefaultScope.present.all).to have(1).item
+      @instance1.recover
+      expect(SpecModelWithDefaultScope.present.all).to have(2).items
+    end
+
+    it "can update a deleted instance" do
+      @instance1.destroy
+      @instance1.update(name: 'baz')
+
+      expect(SpecModelWithDefaultScope.with_deleted.where(name: 'baz').count).to eql(1)
+    end
+
+    it "can save a deleted instance" do
+      @instance1.destroy
+      @instance1.name = 'baz'
+      @instance1.save
+
+      expect(SpecModelWithDefaultScope.with_deleted.where(name: 'baz').count).to eql(1)
     end
   end
 


### PR DESCRIPTION
When a :enable_default_scope option is true, a record cannot be updated or recovered because `deleted_at IS NULL` is applied to database update SQL.  

This patch will reconstruct Sequel's `_update_dataset` to remove the deleted default scope in order to execute the query in this case.

Tests for `recover`, `update`, and `save` have been added to the default_scope test suite. 
