### PR TITLE
Fix inappropriate true value for `#deleted?` on new models

### DIFF
--- a/lib/sequel/plugins/paranoid.rb
+++ b/lib/sequel/plugins/paranoid.rb
@@ -103,7 +103,7 @@ module Sequel::Plugins
 
       def deleted?
         opts = self.class.sequel_paranoid_options
-        send(opts[:deleted_at_field_name]) != opts[:deleted_column_default]
+        send(opts[:deleted_at_field_name]) != opts[:deleted_column_default] && !new?
       end
 
     end
@@ -178,7 +178,7 @@ module Sequel::Plugins
           return super(*columns) unless columns.last.kind_of?(Hash) && columns.last.delete(:paranoid)
 
           opts = self.class.sequel_paranoid_options
-          if deleted?
+          if deleted? || (new? && send(opts[:deleted_at_field_name]))
             columns = columns.map { |c|
               case c
               when Array, Symbol

--- a/spec/sequel/plugins/paranoid_spec.rb
+++ b/spec/sequel/plugins/paranoid_spec.rb
@@ -207,6 +207,11 @@ describe Sequel::Plugins::Paranoid do
     it "returns false if deleted_at is null" do
       expect(@instance2.deleted?).to be false
     end
+
+    it "returns false for new unsaved models" do
+      expect(SpecModel.new.deleted?).to be false
+      expect(SpecModelWithColumnDefault.new.deleted?).to be false
+    end
   end
 
   describe :default_scope do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,10 @@ class SpecModelWithDeletedBy < Sequel::Model
   plugin :paranoid, soft_delete_on_destroy: true, :enable_deleted_by => true
 end
 
+class SpecModelWithColumnDefault < SpecModel
+  plugin :paranoid, soft_delete_on_destroy: true, :deleted_column_default => Time.at(0)
+end
+
 class SpecModelWithCascadeDelete < SpecModel
   plugin :paranoid, soft_delete_on_destroy: true
   one_to_many :spec_fragment


### PR DESCRIPTION
This fixes an issue where `#deleted?` would return true on new (unsaved) models when the `deleted_column_default` value is non-nil. Since this column is always `nil` until the model is persisted, the previous definition of `#deleted?` would compare this `nil` value with the non-nil value in `deleted_column_default` and so always return true.

The tests were always using a `nil` default value, and so were missing this scenario.

I also had to make a slight tweak to the `validates_unique` override because of this. `new? && send(opts[:deleted_at_field_name])` should appropriately cover the case of preventing creation of a new record with an already-used `deleted_at`, since any non-nil value for a new record would had to have been manually set.